### PR TITLE
Fix libg.so check for ARM

### DIFF
--- a/patcher.py
+++ b/patcher.py
@@ -286,7 +286,7 @@ if root.get('package') != config['package']:
 
 print('Checking libg.so ...')
 
-if not os.path.isfile(LIBG_X86):
+if not os.path.isfile(LIBG_ARM):
     print('ERROR: arm libg.so is missing.', file=sys.stderr)
     sys.exit(1)
 


### PR DESCRIPTION
Hey, I know this is old, and IDK it if still works. However, I was curious about it, so I read through the code. When I was reading through it, I noticed a mistake:

[This code](https://github.com/clugh/coc-patcher/blob/e7ff39469c376e21fd37aea373a4ca617edc8687/patcher.py#L289C1-L295C16) checks that the x86 and arm versions of libg.so are not missing:

```py
if not os.path.isfile(LIBG_X86):
    print('ERROR: arm libg.so is missing.', file=sys.stderr)
    sys.exit(1)

if not os.path.isfile(LIBG_X86):
    print('ERROR: x86 libg.so is missing.', file=sys.stderr)
    sys.exit(1)
```

But this code has a mistake: The check for the **arm** version of ligb.so _actually_ checks for the **x86** version.

Here's the fixed version:

```py
if not os.path.isfile(LIBG_ARM):
    print('ERROR: arm libg.so is missing.', file=sys.stderr)
    sys.exit(1)

if not os.path.isfile(LIBG_X86):
    print('ERROR: x86 libg.so is missing.', file=sys.stderr)
    sys.exit(1)
```